### PR TITLE
feat: adds calendar resource dispatch functions

### DIFF
--- a/src/calendar/dispatch.ts
+++ b/src/calendar/dispatch.ts
@@ -1,0 +1,124 @@
+/**
+ * these are "dispatch helpers"
+ * the only allowed side effect is to call a supplied "dispatch" function
+ * otherwise only use pure functions
+ *
+ * the goal is to remove the pure functions (often contain messy looking
+ * maps & reducers with ternarys & spread operators) from the component files.
+ */
+import { Action, CalendarAction, CalendarState } from "./types";
+import { ResourceKey } from "../resources/types";
+import Location from "../resources/Location";
+import Project from "../resources/Project";
+import { setPropIf } from "../utils/setPropIf";
+
+const setSelectedByCourseTitle = (
+  courseTitle: string,
+  selected: boolean
+): ((p: Project) => Project) =>
+  setPropIf<Project>(
+    (p) => p.course.title === courseTitle,
+    "selected",
+    selected
+  );
+
+const toggleProjectSelectedByCourse = (
+  projects: Project[],
+  courseTitle: string,
+  selected: boolean
+): Project[] =>
+  projects.reduce(
+    (marked, project) => [
+      ...marked,
+      setSelectedByCourseTitle(courseTitle, selected)(project),
+    ],
+    [] as Project[]
+  );
+
+export const dispatchSelectedProjectsByCourse = (
+  state: CalendarState,
+  dispatch: (action: Action) => void,
+  id: string,
+  selected: boolean
+): void =>
+  dispatch({
+    type: CalendarAction.SelectedProject,
+    payload: {
+      resources: {
+        [ResourceKey.Projects]: toggleProjectSelectedByCourse(
+          state.resources[ResourceKey.Projects] as Project[],
+          id,
+          selected
+        ),
+      },
+    },
+  });
+
+export const dispatchSelectedProject = (
+  state: CalendarState,
+  dispatch: (action: Action) => void,
+  id: number,
+  selected?: boolean
+): void =>
+  dispatch({
+    type: CalendarAction.SelectedProject,
+    payload: {
+      resources: {
+        [ResourceKey.Projects]: (state.resources[
+          ResourceKey.Projects
+        ] as Project[]).map(
+          setPropIf<Project>(
+            (project) => project.id === id,
+            "selected",
+            selected
+          )
+        ),
+      },
+    },
+  });
+
+export const dispatchSelectedLocation = (
+  state: CalendarState,
+  dispatch: (action: Action) => void,
+  id: string,
+  selected: boolean
+): void =>
+  dispatch({
+    type: CalendarAction.SelectedLocation,
+    payload: {
+      resources: {
+        [ResourceKey.Locations]: (state.resources[
+          ResourceKey.Locations
+        ] as Location[]).map(
+          setPropIf<Location>(
+            (location) => location.groupId === id,
+            "selected",
+            selected
+          )
+        ),
+      },
+    },
+  });
+
+export const dispatchSelectedLocationGroup = (
+  state: CalendarState,
+  dispatch: (action: Action) => void,
+  id: number,
+  selected: boolean
+): void =>
+  dispatch({
+    type: CalendarAction.SelectedLocation,
+    payload: {
+      resources: {
+        [ResourceKey.Locations]: (state.resources[
+          ResourceKey.Locations
+        ] as Location[]).map(
+          setPropIf<Location>(
+            (location) => location.id === id,
+            "selected",
+            selected
+          )
+        ),
+      },
+    },
+  });

--- a/src/components/ProjectExpansionList.tsx
+++ b/src/components/ProjectExpansionList.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent, useContext } from "react";
-import { CalendarUIProps, CalendarAction } from "../calendar/types";
+import React, { FunctionComponent } from "react";
+import { CalendarUIProps } from "../calendar/types";
 import {
   ExpansionPanel,
   ExpansionPanelSummary,
@@ -10,17 +10,9 @@ import {
   Checkbox,
 } from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import { makeStyles } from "@material-ui/core/styles";
 import ProjectListItem from "./ProjectListItem";
-import { AuthContext } from "./AuthContext";
 import Project from "../resources/Project";
-import { ResourceKey } from "../resources/types";
-
-const useStyles = makeStyles(() => ({
-  nopadding: {
-    padding: 0,
-  },
-}));
+import { dispatchSelectedProjectsByCourse } from "../calendar/dispatch";
 
 interface ProjectExpansionListProps extends CalendarUIProps {
   parentId: string | number;
@@ -33,8 +25,6 @@ const ProjectExpansionList: FunctionComponent<ProjectExpansionListProps> = ({
   parentId,
   projects,
 }) => {
-  const { user } = useContext(AuthContext);
-  const classes = useStyles();
   const checked = projects.every((project) => project.selected);
   const indeterminate =
     !checked && projects.some((project) => project.selected);
@@ -57,26 +47,16 @@ const ProjectExpansionList: FunctionComponent<ProjectExpansionListProps> = ({
           onClick={(event): void => event.stopPropagation()}
           onChange={(event: React.ChangeEvent<{}>, checked): void => {
             event.stopPropagation();
-            dispatch({
-              type: CalendarAction.SelectedProject,
-              payload: {
-                resources: {
-                  //! TODO check that this is working - major refactor
-                  ...state.resources,
-                  [ResourceKey.Projects]: state.resources[
-                    ResourceKey.Projects
-                  ].map((project) => {
-                    if ((project as Project).course.title === parentId)
-                      project.selected = checked;
-                    return project;
-                  }),
-                },
-              },
-            });
+            dispatchSelectedProjectsByCourse(
+              state,
+              dispatch,
+              parentId as string,
+              checked
+            );
           }}
         />
       </ExpansionPanelSummary>
-      <ExpansionPanelDetails classes={{ root: classes.nopadding }}>
+      <ExpansionPanelDetails>
         <List>
           {projects.map((project) => (
             <ProjectListItem

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -1,28 +1,19 @@
 import React, { FunctionComponent } from "react";
-import { makeStyles } from "@material-ui/core/styles";
 import { CalendarUIProps } from "../calendar/types";
 import ProjectExpansionList from "./ProjectExpansionList";
-// import ProjectListItem from "./ProjectListItem";
 import { Typography } from "@material-ui/core";
 import { ResourceKey } from "../resources/types";
 import Project from "../resources/Project";
 import Course from "../resources/Course";
 
-const useStyles = makeStyles({
-  root: {
-    width: "100%",
-  },
-});
-
 const ProjectList: FunctionComponent<CalendarUIProps> = ({
   dispatch,
   state,
 }) => {
-  const classes = useStyles();
   const projects = state.resources[ResourceKey.Projects] as Project[];
   const courses = state.resources[ResourceKey.Courses] as Course[];
   return (
-    <div className={classes.root}>
+    <div>
       {projects.length ? <Typography variant="body1">Projects</Typography> : ""}
       {courses &&
         courses.map((course, index) => (

--- a/src/components/ProjectListItem.tsx
+++ b/src/components/ProjectListItem.tsx
@@ -6,10 +6,11 @@ import {
   ListItem,
   ListItemText,
   Divider,
+  FormControlLabel,
 } from "@material-ui/core";
 import InfoIcon from "@material-ui/icons/Info";
 import Project from "../resources/Project";
-import { ResourceKey } from "../resources/types";
+import { dispatchSelectedProject } from "../calendar/dispatch";
 
 interface ProjectListItemProps extends CalendarUIProps {
   project: Project;
@@ -24,55 +25,18 @@ const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({
     <ListItem
       button
       key={project.id}
-      onClick={(event): void => {
-        event.stopPropagation();
-        dispatch({
-          type: CalendarAction.SelectedProject,
-          payload: {
-            resources: {
-              ...state.resources,
-              [ResourceKey.Projects]: state.resources[ResourceKey.Projects].map(
-                (proj) => {
-                  if (proj.id !== project.id) {
-                    return proj;
-                  }
-                  proj.selected = !proj.selected;
-                  return proj;
-                }
-              ),
-            },
-          },
-        });
-      }}
+      onClick={(event): void => event.stopPropagation()}
     >
-      <Checkbox
+      <FormControlLabel
         checked={project.selected || false}
-        size="small"
-        inputProps={{ "aria-label": "checkbox with small size" }}
-        key={project.title}
+        control={<Checkbox />}
+        label={<ListItemText primary={project.title} />}
         onClick={(event): void => event.stopPropagation()}
-        onChange={(event: React.ChangeEvent, checked): void => {
+        onChange={(event: React.ChangeEvent<{}>, checked): void => {
           event.stopPropagation();
-          dispatch({
-            type: CalendarAction.SelectedProject,
-            payload: {
-              resources: {
-                ...state.resources,
-                [ResourceKey.Projects]: state.resources[
-                  ResourceKey.Projects
-                ].map((proj) => {
-                  if (proj.id !== project.id) {
-                    return proj;
-                  }
-                  proj.selected = checked;
-                  return proj;
-                }),
-              },
-            },
-          });
+          dispatchSelectedProject(state, dispatch, project.id, checked);
         }}
       />
-      <ListItemText primary={project.title} />
       <Divider orientation="vertical" flexItem />
       <IconButton
         key={project.id}

--- a/src/components/ResourceExpansionList.tsx
+++ b/src/components/ResourceExpansionList.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react";
-import { CalendarUIProps, CalendarAction } from "../calendar/types";
+import { CalendarUIProps } from "../calendar/types";
 import {
   ExpansionPanel,
   ExpansionPanelSummary,
@@ -10,15 +10,9 @@ import {
 } from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import ResourceListItem from "./ResourceListItem";
-import { makeStyles } from "@material-ui/core/styles";
 import Location from "../resources/Location";
 import { ResourceKey } from "../resources/types";
-
-const useStyles = makeStyles(() => ({
-  nopadding: {
-    padding: 0,
-  },
-}));
+import { dispatchSelectedLocation } from "../calendar/dispatch";
 
 interface ResourceExpansionListProps extends CalendarUIProps {
   groupId: string;
@@ -29,7 +23,6 @@ const ResourceExpansionList: FunctionComponent<ResourceExpansionListProps> = ({
   groupId,
 }) => {
   const locations = state.resources[ResourceKey.Locations] as Location[];
-  const classes = useStyles();
   const groupLocations = locations.filter(
     (location) => location.groupId === groupId
   );
@@ -54,25 +47,11 @@ const ResourceExpansionList: FunctionComponent<ResourceExpansionListProps> = ({
           onClick={(event): void => event.stopPropagation()}
           onChange={(event: React.ChangeEvent<{}>, checked): void => {
             event.stopPropagation();
-            dispatch({
-              type: CalendarAction.SelectedLocation,
-              payload: {
-                resources: {
-                  ...state.resources,
-                  [ResourceKey.Locations]: locations.map((location) => {
-                    if (location.groupId !== groupId) {
-                      return location;
-                    }
-                    location.selected = checked;
-                    return location;
-                  }),
-                },
-              },
-            });
+            dispatchSelectedLocation(state, dispatch, groupId, checked);
           }}
         />
       </ExpansionPanelSummary>
-      <ExpansionPanelDetails classes={{ root: classes.nopadding }}>
+      <ExpansionPanelDetails>
         <List>
           {locations
             .filter((location) => location.groupId === groupId)

--- a/src/components/ResourceList.tsx
+++ b/src/components/ResourceList.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent } from "react";
-import { makeStyles } from "@material-ui/core/styles";
 import { CalendarUIProps } from "../calendar/types";
 import { locationGroupReducer } from "../resources/Location";
 import ResourceListItem from "./ResourceListItem";
@@ -8,12 +7,6 @@ import { ExpansionPanelSummary, ExpansionPanel } from "@material-ui/core";
 import { ResourceKey } from "../resources/types";
 import Location from "../resources/Location";
 
-const useStyles = makeStyles({
-  root: {
-    width: "100%",
-  },
-});
-
 const ResourceList: FunctionComponent<CalendarUIProps> = ({
   dispatch,
   state,
@@ -21,9 +14,8 @@ const ResourceList: FunctionComponent<CalendarUIProps> = ({
   const locations = state.resources[ResourceKey.Locations] as Location[];
   const groups = locations.reduce(locationGroupReducer, {});
   const singletons = locations.filter((location) => !location.groupId);
-  const classes = useStyles();
   return (
-    <div className={classes.root}>
+    <div>
       {groups &&
         Object.keys(groups).map((key) => (
           <ResourceExpansionList

--- a/src/components/ResourceListItem.tsx
+++ b/src/components/ResourceListItem.tsx
@@ -1,8 +1,13 @@
 import React, { FunctionComponent } from "react";
-import { CalendarUIProps, CalendarAction } from "../calendar/types";
-import { ListItem, ListItemText, Checkbox } from "@material-ui/core";
+import { CalendarUIProps } from "../calendar/types";
+import {
+  ListItem,
+  ListItemText,
+  Checkbox,
+  FormControlLabel,
+} from "@material-ui/core";
 import Location from "../resources/Location";
-import { ResourceKey } from "../resources/types";
+import { dispatchSelectedLocationGroup } from "../calendar/dispatch";
 
 interface ResourceListItemProps extends CalendarUIProps {
   location: Location;
@@ -15,34 +20,17 @@ const ResourceListItem: FunctionComponent<ResourceListItemProps> = ({
 }) => {
   return (
     <ListItem button key={location.id}>
-      <Checkbox
-        checked={location.selected}
-        size="small"
-        inputProps={{ "aria-label": "checkbox with small size" }}
+      <FormControlLabel
+        control={<Checkbox />}
+        label={<ListItemText primary={location.title} />}
+        checked={location.selected || false}
         key={location.id}
         onClick={(event): void => event.stopPropagation()}
         onChange={(event: React.ChangeEvent<{}>, checked): void => {
           event.stopPropagation();
-          dispatch({
-            type: CalendarAction.SelectedLocation,
-            payload: {
-              resources: {
-                ...state.resources,
-                [ResourceKey.Locations]: state.resources[
-                  ResourceKey.Locations
-                ].map((loc) => {
-                  if (loc.id !== location.id) {
-                    return loc;
-                  }
-                  loc.selected = checked;
-                  return loc;
-                }),
-              },
-            },
-          });
+          dispatchSelectedLocationGroup(state, dispatch, location.id, checked);
         }}
       />
-      <ListItemText primary={location.title} />
     </ListItem>
   );
 };

--- a/src/utils/setPropIf.ts
+++ b/src/utils/setPropIf.ts
@@ -1,0 +1,8 @@
+export function setPropIf<T>(
+  predicateFn: (resource: T) => boolean,
+  key: string,
+  value: unknown
+) {
+  return (resource: T): T =>
+    predicateFn(resource) ? { ...resource, [key]: value } : { ...resource };
+}


### PR DESCRIPTION
Fixes inconsistencies in project & location checkboxes (use `<FormControlLabel>`).
Extracts data processing when toggling checkboxes into separate dispatch-helper file.
Removes duplicated instances of `useStyles` for now.  We can return to it, but we should probably   use _one_ `useStyles`, or our own custom wrapper, in a separate file, that these similar components can share.