### PR TITLE
fix: types Reservation id as number

### DIFF
--- a/src/resources/Reservation.ts
+++ b/src/resources/Reservation.ts
@@ -6,7 +6,7 @@ interface ActionDetails {
 
 interface Reservation {
   [k: string]: unknown;
-  id: 0;
+  id: number;
   description: string;
   eventId: number;
   projectId: number;


### PR DESCRIPTION
Reservation id was set to 0, rather than number.
I am assuming this was a typo.